### PR TITLE
Feature/project modal fixed

### DIFF
--- a/src/pages/projects/components/CreateProjectModal/CreateProjectModal.tsx
+++ b/src/pages/projects/components/CreateProjectModal/CreateProjectModal.tsx
@@ -7,7 +7,7 @@ import InputWithCalendarArea from '@components/common/InputArea/InputWithCalenda
 import InputWithIconArea from '@components/common/InputArea/InputWithIconArea';
 import InputWithTimePicker from '@components/common/InputArea/InputWithTimePicker';
 import Toggle from '@components/common/Toggle/Toggle';
-import useModal from '@hooks/useModal';
+import { modalStore } from '@libs/store';
 import {
   useProjectActions,
   useProjectState,
@@ -45,8 +45,6 @@ interface Temp {
 }
 
 function CreateProjectModal() {
-  const [closeModal] = useModal();
-
   const { title, thumbnail, subTitle, description, startDate, endDate } =
     useProjectState();
   const {
@@ -60,6 +58,7 @@ function CreateProjectModal() {
 
   const [includeTime, setIncludeTime] = useState(false);
   const { createProjectMutate } = useCreateProject();
+  const { closeModal } = modalStore();
 
   useEffect(() => {
     clearProject();
@@ -69,13 +68,14 @@ function CreateProjectModal() {
     createProjectMutate(newProject);
 
   const handleCreateProject = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
     const newProject = {
       title,
       thumbnail,
       subTitle,
       description,
     };
+    if (!title || !subTitle || !description || !startDate || !endDate)
+      return e.preventDefault();
     if (
       startDate &&
       endDate &&
@@ -96,6 +96,7 @@ function CreateProjectModal() {
         thumbnailType: thumbnail.type,
       });
     }
+    return closeModal();
     /*
     프로젝트 기간이 required인 이슈가 해결될 때
     기간이 빠진 new Project 서버에 보내는 함수 작성 예정
@@ -106,7 +107,7 @@ function CreateProjectModal() {
     <>
       <StyleCreateProjectModal.Header>
         <h1>프로젝트 추가</h1>
-        <button>
+        <button onClick={closeModal}>
           <img src={CancelButton} alt="닫기" />
         </button>
       </StyleCreateProjectModal.Header>
@@ -182,8 +183,11 @@ function CreateProjectModal() {
             size="medium"
             variant="text"
             $hasIcon={false}
-            onClick={() => closeModal(CreateProjectModal)}
-            text="취소"
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              return clearProject();
+            }}
+            text="되돌리기"
           />
           <Button
             size="medium"

--- a/src/pages/projects/components/DeleteProjectModal/DeleteProjectModal.tsx
+++ b/src/pages/projects/components/DeleteProjectModal/DeleteProjectModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import { Button } from '@components/common/Button';
 import InputArea from '@components/common/InputArea';
+import { modalStore } from '@libs/store';
 import {
   useDeleteProject,
   useGetProject,
@@ -17,14 +18,13 @@ const DeleteProjectModal = ({ projectId }: DeleteProjectModalProps) => {
   const [retypeProjectTitle, setRetypeProjectTitle] = useState('');
   const { project } = useGetProject(projectId);
   const { deleteProjectMutate } = useDeleteProject();
+  const { closeModal } = modalStore();
 
-  const handleDeleteProject = async (
-    e: React.MouseEvent<HTMLButtonElement>,
-  ) => {
-    e.preventDefault();
+  const handleDeleteProject = () => {
     if (retypeProjectTitle === project?.title) {
       deleteProjectMutate(projectId);
     }
+    return closeModal();
   };
 
   return (
@@ -59,7 +59,7 @@ const DeleteProjectModal = ({ projectId }: DeleteProjectModalProps) => {
             variant="text"
             $hasIcon={false}
             text="취소"
-            onClick={() => console.log('취소')}
+            onClick={closeModal}
           />
           <Button
             size="medium"

--- a/src/pages/projects/components/ModifyProjectModal/ModifyProjectModal.tsx
+++ b/src/pages/projects/components/ModifyProjectModal/ModifyProjectModal.tsx
@@ -8,7 +8,7 @@ import InputWithIconArea from '@components/common/InputArea/InputWithIconArea';
 import InputWithTimePicker from '@components/common/InputArea/InputWithTimePicker';
 import Toggle from '@components/common/Toggle/Toggle';
 import { RawProject } from '@customTypes/project';
-import useModal from '@hooks/useModal';
+import { modalStore } from '@libs/store';
 import {
   useProjectActions,
   useProjectState,
@@ -24,11 +24,10 @@ interface ModifyProjectModalProps {
 }
 
 function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
-  const [closeModal] = useModal();
-
   const { project, isLoading } = useGetProject(projectId);
   const { editProjectMutate } = useEditProject();
   const [includeTime, setIncludeTime] = useState(false);
+  const { closeModal } = modalStore();
 
   const { title, thumbnail, subTitle, description, startDate, endDate } =
     useProjectState();
@@ -39,6 +38,7 @@ function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
     setDescription,
     setStartDate,
     setEndDate,
+    // clearProject,
   } = useProjectActions();
 
   useEffect(() => {
@@ -53,8 +53,7 @@ function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
     editProjectMutate(editedProject);
   };
 
-  const handleModifyProject = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  const handleModifyProject = () => {
     const editedProject = {
       projectId,
       title,
@@ -82,6 +81,7 @@ function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
         thumbnailType: thumbnail.type,
       });
     }
+    return closeModal();
     /*
     프로젝트 기간이 required인 이슈가 해결될 때
     기간이 빠진 editedProject를 서버에 보내는 함수 작성 예정
@@ -93,7 +93,7 @@ function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
     <>
       <StyleModifyProjectModal.Header>
         <h1>프로젝트 설정</h1>
-        <button>
+        <button onClick={closeModal}>
           <img src={CancelButton} alt="닫기" />
         </button>
       </StyleModifyProjectModal.Header>
@@ -174,7 +174,7 @@ function ModifyProjectModal({ projectId }: ModifyProjectModalProps) {
             size="medium"
             variant="text"
             $hasIcon={false}
-            onClick={() => closeModal(ModifyProjectModal)}
+            onClick={closeModal}
             text="취소"
           />
           <Button

--- a/src/pages/projects/components/ProjectBoardItem/ProjectBoardItem.tsx
+++ b/src/pages/projects/components/ProjectBoardItem/ProjectBoardItem.tsx
@@ -120,11 +120,8 @@ const DescriptionFrame = styled.div`
 `;
 
 const ProjectBoardItem = ({ project }: { project: RawProject }) => {
-  const [
-    isOpenProjectDropdownMenu,
-    toggleProjectDropdownMenu,
-    projectDropdownMenuRef,
-  ] = useDropdown();
+  const [isOpenProjectDropdownMenu, toggleProjectDropdownMenu, dropdownRef] =
+    useDropdown();
 
   // 진행 중 / 완료
   const progressValue =
@@ -153,13 +150,14 @@ const ProjectBoardItem = ({ project }: { project: RawProject }) => {
           <h5>{project.subTitle}</h5>
           <h2>{project.title}</h2>
         </StyleProjectBoard.Title>
-        <MeatBalls ref={projectDropdownMenuRef}>
+        <MeatBalls ref={dropdownRef}>
           <img
             src={meatballs}
             alt="보드 더보기"
             onClick={toggleProjectDropdownMenu}
           />
           <ProjectSettingsDropdown
+            toggleProjectDropdownMenu={toggleProjectDropdownMenu}
             isOpen={isOpenProjectDropdownMenu}
             projectId={project.projectId}
           />

--- a/src/pages/projects/components/ProjectSettingsDropdown/ProjectSettingsDropdown.tsx
+++ b/src/pages/projects/components/ProjectSettingsDropdown/ProjectSettingsDropdown.tsx
@@ -13,11 +13,13 @@ import ModifyProjectModal from '@pages/projects/components/ModifyProjectModal/Mo
 interface ProjectSettingsDropdownProps {
   isOpen: boolean;
   projectId: number;
+  toggleProjectDropdownMenu: () => void;
 }
 
 const ProjectSettingsDropdown = ({
   isOpen,
   projectId,
+  toggleProjectDropdownMenu,
 }: ProjectSettingsDropdownProps) => {
   const [openModal] = useModal();
 
@@ -27,19 +29,26 @@ const ProjectSettingsDropdown = ({
         <DropdownItem
           text="프로젝트 삭제"
           Icon={TrashCan}
-          onClick={() => openModal(() => DeleteProjectModal({ projectId }))}
+          onClick={() => {
+            openModal(() => DeleteProjectModal({ projectId }));
+            toggleProjectDropdownMenu();
+          }}
         />
         <DropdownItem
           text="프로젝트 설정"
           Icon={Settings}
           onClick={() => {
             openModal(() => ModifyProjectModal({ projectId }));
+            toggleProjectDropdownMenu();
           }}
         />
         <DropdownItem
           text="프로젝트 탈퇴"
           Icon={Withdraw}
-          onClick={() => console.log('구현 예정')}
+          onClick={() => {
+            // console.log('구현 예정');
+            toggleProjectDropdownMenu();
+          }}
         />
       </DropdownItemList>
     </DropdownWrapper>

--- a/src/pages/projects/list/index.tsx
+++ b/src/pages/projects/list/index.tsx
@@ -150,6 +150,7 @@ const ProjectList = () => {
                     <ProjectSettingsDropdown
                       isOpen={isOpenProjectDropdownMenu}
                       projectId={project.projectId}
+                      toggleProjectDropdownMenu={toggleProjectDropdownMenu}
                     />
                   </MeatBalls>
                 </td>

--- a/src/routes/SettingsRoute.tsx
+++ b/src/routes/SettingsRoute.tsx
@@ -3,10 +3,10 @@
  */
 import { Route, Routes } from 'react-router-dom';
 
-import Settings from '@pages/Settings';
-import AlarmSettings from '@pages/Settings/Alarm';
-import MembersSettings from '@pages/Settings/Members';
-import ProjectSettings from '@pages/Settings/Project';
+import Settings from '@pages/settings';
+import AlarmSettings from '@pages/settings/Alarm';
+import MembersSettings from '@pages/settings/Members';
+import ProjectSettings from '@pages/settings/Project';
 
 const SettingsRoute = () => (
   <Routes>


### PR DESCRIPTION
# 작업사항 👾
## 모달창, 토글
- 닫힘 기능
  - CRUD 모달창에서 원활하게 닫힐 수 있는 기능을 추가했습니다.
  - 모달창이 닫혀도 리렌더링이 발생하지 않도록 조정했습니다.
  - 토글 클릭 시 닫히지 않던 문제도 함께 수정했습니다.
- 프로젝트 생성 모달창
  - 전체 내용을 입력하지 않았을 때, 확인 버튼을 눌러도 모달이 닫히지 않도록 개선했습니다.
  - 하단의 취소 버튼을 되돌리기 버튼으로 변경했습니다.

## setting 폴더 경로 이름 수정
- 페이지 경로를 `Setting`에서 `setting`으로 수정했습니다.

# 질문 🍋
안녕하세요! 😊  
모달 창이 닫힐 때 리렌더링을 방지하기 위해 기존의 `e.preventDefault`를 제거하고, 대신 `return`으로 처리했습니다.  
그리고 되돌리기 기능은 구현된 함수의 특성상 모든 내용이 지워지기 때문에, 현재는 생성 모달창에만 적용해두었습니다. 궁금한 점이나 추가로 전달해주실 내용이 있으시면 언제든지 말씀해 주세요!
